### PR TITLE
Add authentication arguments to @MavenRepository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.github.holgerbrandl'
-version = '1.1'
+version = '1.3'
 
 buildscript {
     ext.kotlin_version = '1.1.60'

--- a/src/main/kotlin/ScriptDirectives.kt
+++ b/src/main/kotlin/ScriptDirectives.kt
@@ -44,5 +44,4 @@ annotation class DependsOnMaven(val artifactLocator: String)
 // in contrast to the original version we make the id mandatory here.
 // This keeps ensures compatiblity with keplin but eases parsing
 //annotation class MavenRepository(val id: String = "", val url: String)
-annotation class MavenRepository(val id: String, val url: String)
-
+annotation class MavenRepository(val id: String, val url: String, val user: String = "", val pass: String = "")


### PR DESCRIPTION
Add support for Authentication in the @MavenRepository annotation as described in https://github.com/holgerbrandl/kscript/pull/214

I took the liberty of updating the plugin-version to the next logical version after the one referenced in the main plugin: https://github.com/holgerbrandl/kscript/blob/master/src/main/kotlin/kscript/app/Script.kt#L132