### PR TITLE
Re-add @file:CompilerOpts annotation from 1.2 + bump to 1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.github.holgerbrandl'
-version = '1.3'
+version = '1.4'
 
 buildscript {
     ext.kotlin_version = '1.1.60'

--- a/src/main/kotlin/ScriptDirectives.kt
+++ b/src/main/kotlin/ScriptDirectives.kt
@@ -27,6 +27,13 @@ annotation class Include(val includePath: String)
 annotation class KotlinOpts(val runOptions: String)
 
 
+@Target(AnnotationTarget.FILE)
+@Retention(AnnotationRetention.SOURCE)
+@MustBeDocumented
+@Repeatable
+annotation class CompilerOpts(val kotlincFlags: String)
+
+
 // MavenRepository and DependsOnMaven are supported "as it" for compatibility with jupyter notebooks.
 // see https://github.com/kohesive/keplin/blob/master/keplin-maven-resolver/src/main/kotlin/uy/kohesive/keplin/kotlin/script/resolver/maven/MavenResolverAnnotations.kt
 // example https://github.com/kohesive/keplin/blob/a307e05eae091c99c665fe3da52a428fb0e10a6a/keplin-maven-resolver/src/test/kotlin/uy/kohesive/keplin/kotlin/script/resolver/maven/TestMavenScriptDependencies.kt#L38
@@ -38,13 +45,6 @@ annotation class KotlinOpts(val runOptions: String)
 @Repeatable
 annotation class DependsOnMaven(val artifactLocator: String)
 
-@Target(AnnotationTarget.FILE)
-@Retention(AnnotationRetention.SOURCE)
-@Repeatable
-// in contrast to the original version we make the id mandatory here.
-// This keeps ensures compatiblity with keplin but eases parsing
-//annotation class MavenRepository(val id: String = "", val url: String)
-
 /**
  * Declare a maven repository that will be used by kscript to resolve dependencies
  *
@@ -53,4 +53,7 @@ annotation class DependsOnMaven(val artifactLocator: String)
  * @param user Optional user name
  * @param password Optional password (required if user is defined)
  */
+@Target(AnnotationTarget.FILE)
+@Retention(AnnotationRetention.SOURCE)
+@Repeatable
 annotation class MavenRepository(val id: String, val url: String, val user: String = "", val password: String = "")


### PR DESCRIPTION
After some puzzling about what was going wrong in my [PR in kscript](https://github.com/holgerbrandl/kscript/pull/214) it appears that you might have forget to push the kscript-annotations:1.2 changes to github after publishing the artefact, which means the 1.3 is missing the changes form 1.2.

It probably would have been an easy fix for you, but in the interest of moving things along, I simply looked at the bytecode of 1.2 and added the annotation again the way it was defined there. I bumped the version to 1.4 assuming you can't update an already published artefact.

I also removed some commented out code as it seemed to be obsolete.